### PR TITLE
Swagger の導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  swagger:
+    image: swaggerapi/swagger-ui
+    ports:
+      - "8000:8080"
+    environment:
+      - API_URL=http://localhost:8000/api/swagger.yaml
+    volumes:
+      - ./docs:/usr/share/nginx/html/api

--- a/docs/sequence.puml
+++ b/docs/sequence.puml
@@ -1,0 +1,58 @@
+@startuml nimmt
+
+actor User as user
+entity "Nimmt!" as nimmt
+entity Notice as notice
+
+autonumber "<b>[0]"
+
+== 準備フェーズ ==
+
+user -> nimmt: テーブルを作成する
+nimmt -->> notice: CreateTable
+nimmt -> nimmt: ステータス：TableCreated
+nimmt --> user: テーブル ID
+
+loop poling
+  user -> nimmt: テーブル情報を取得する
+  nimmt --> user: テーブル情報 (並んでいるカード, ステータス)
+
+  ref over user
+    ステータスに従い処理
+  end ref
+end
+
+loop プレイヤー数
+  user -> nimmt: 参加する (テーブル ID)
+  nimmt -->> notice: JoinPlayer
+  nimmt --> user: アクセストークン（テーブル ID、手札カード）
+end
+
+user -> nimmt: プレイヤー情報を取得する
+nimmt --> user: プレイヤー情報
+
+user -> nimmt: ゲーム開始
+nimmt -> nimmt: カードを 4 枚テーブルに並べる
+nimmt -->> notice: LineUpCards
+nimmt -> nimmt: ステータス：Selecting
+
+== 進行フェーズ ==
+
+loop プレイヤー数
+  user -> nimmt: カードを選ぶ (数字)
+
+  alt 全員選択
+    nimmt -> nimmt: ステータス：Selected
+
+    nimmt -> nimmt: 選んだカードをテーブルに並べる
+    nimmt -->> notice: LineUpCards
+  end
+end
+
+user -> nimmt: 次のラウンドを開始する
+nimmt -> nimmt: ステータス：Selecting
+nimmt -> notice: NextRound
+
+== 得点計算 ==
+
+@enduml

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.0
+servers:
+  - description: ローカル
+    url: https://localhost:8080/v1
+info:
+  description: ゲームの土台となる API です
+  version: "0.1.0"
+  title: Game Base API
+  contact:
+    email: syslink.h.inoue@gmail.com
+tags:
+  - name: table
+paths:
+  /tables:
+    post:
+      tags:
+        - table
+      summary: テーブルを作成する
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TableResponse'
+  /tables/{tableId}:
+    post:
+      tags:
+        - table
+      summary: テーブルの情報を取得する
+      parameters:
+        - name: tableId
+          in: path
+          description: テーブル ID
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TableResponse'
+
+components:
+  schemas:
+    TableResponse:
+      required:
+        - tableId
+      properties:
+        tableId:
+          description: テーブル ID
+          type: string
+          example: 550e8400-e29b-41d4-a716-446655440000
+      type: object


### PR DESCRIPTION
## 概要
Swagger をローカルで作れるように環境を作りました。
あわせて `テーブルを作成する` と `テーブル情報を取得する` のシーケンスの API 設計を作成しています。
まだ仕様が詰め切れてないので、たたきとしてテーブル ID を `UUID` 形式で生成して返して、それを取得するだけの単純な API になっています。
仕様を詰める中で、必要に応じて拡張して行こうと思います。

### シーケンス
![image](https://user-images.githubusercontent.com/1096516/66350407-2d8b9780-e996-11e9-8bae-32f765c229d1.png)

### API 設計
![image](https://user-images.githubusercontent.com/1096516/66350855-4ea0b800-e997-11e9-9e50-2a5d0978cd23.png)
![image](https://user-images.githubusercontent.com/1096516/66350895-65dfa580-e997-11e9-8e9f-e43b511bc15c.png)

### 前提条件
docker for mac をインストールする

### API 確認方法

```sh
$ docker-compose up
```

ブラウザを開いて `http://localhost:8000/` を開く
もしくは
vscode に `Swagger Viewer` を使用する