### PR TITLE
Heroku に合わせてデータベースを postgresql に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 - Python のインストール
 - pip
   - Django のインストール
-  - mysqlclient のインストール
+  - mysql の場合
+    - mysqlclient のインストール
+  - postgreslq の場合
+    - psycopg2-binary のインストール
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,26 @@
 version: '3'
 
 services:
+  # db:
+  #   image: mysql
+  #   command: --default-authentication-plugin=mysql_native_password
+  #   volumes:
+  #     - db_data:/var/lib/mysql
+  #   restart: always
+  #   environment:
+  #     MYSQL_ROOT_PASSWORD: password
+  #   ports:
+  #   - 3306:3306
   db:
-    image: mysql
-    command: --default-authentication-plugin=mysql_native_password
+    image: postgres
     volumes:
-      - db_data:/var/lib/mysql
+      - db_data:/docker-entrypoint-initdb.d
     restart: always
-    environment:
-      MYSQL_ROOT_PASSWORD: password
     ports:
-    - 3306:3306
+      - 5432:5432
+    environment:
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: service_api_development
   swagger:
     image: swaggerapi/swagger-ui
     ports:

--- a/service_api/settings.py
+++ b/service_api/settings.py
@@ -74,14 +74,25 @@ WSGI_APPLICATION = 'service_api.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
 
+# DATABASES = {
+#      'default': {
+#          'ENGINE': 'django.db.backends.mysql',
+#          'NAME': 'service_api_development',
+#          'USER': 'root',
+#          'PASSWORD': 'password',
+#          'HOST': '127.0.0.1',
+#          'PORT': '3306'
+#      }
+# }
+
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.mysql',
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'service_api_development',
-        'USER': 'root',
+        'USER': 'postgres',
         'PASSWORD': 'password',
         'HOST': '127.0.0.1',
-        'PORT': '3306'
+        'PORT': '5432'
     }
 }
 


### PR DESCRIPTION
## 概要
heroku が postgresql なので、一旦切り替えます。
リファクタリングの中で、RDB を Redis を追い出す等の対応を行いたいので、その対応で見直してもいいかと思っています。