### PR TITLE
heroku の設定を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,10 @@
 ## Installation
 
 - Python のインストール
-- pip
-  - Django のインストール
-  - mysql の場合
-    - mysqlclient のインストール
-  - postgreslq の場合
-    - psycopg2-binary のインストール
 
 ## Usage
 
 ```
+$ pip3 install -r requirements.txt
 $ python manage.py runserver
 ```

--- a/docs/apis/restclient.http
+++ b/docs/apis/restclient.http
@@ -1,5 +1,5 @@
 @url = http://localhost:8000
-@tableId = f987eabc-defa-4bb1-a837-ed527254984e
+@tableId = 981da4cf-cee6-44cc-9f0a-cf04aeefafb2
 
 ### テーブル作成
 # @name create-table

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Django==3.0.1
+django-extensions==2.2.5
+# mysqlclient==1.4.6
+gunicorn==20.0.4
+django-heroku==0.3.1

--- a/service_api/Procfile
+++ b/service_api/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn myproject.wsgi

--- a/service_api/settings.py
+++ b/service_api/settings.py
@@ -12,6 +12,9 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 
 import os
 
+import django_heroku
+django_heroku.settings(locals())
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 


### PR DESCRIPTION
## 概要
表題のとおり。

ローカルだと下記の部分があるとエラーになるので、暫定的にコメントアウトして動かしています。

```py
import django_heroku
django_heroku.settings(locals())
```

環境ごとにロジックが切りかれればよいのか、heroku としてローカルでの開発はどうすればいいのか調べる必要がありそう。

bundler のように pip も依存関係でインストールする仕組みがあるので、そちらに切り替え。

```
$ pip3 install -r requirements.txt
```